### PR TITLE
スタイリングフォト投稿の編集履歴を実装する #23

### DIFF
--- a/app/Http/Controllers/Admin/FashionController.php
+++ b/app/Http/Controllers/Admin/FashionController.php
@@ -5,8 +5,15 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 
-// Fashion Modelが扱えるように以下の一文を追加
+// Fashion Modelの使用を宣言する
 use App\Models\Fashion;
+
+// History Modelの使用を宣言する
+use App\Models\History;
+
+// 時刻を取得するため、Carbonという日付操作ライブラリの使用を宣言する
+use Carbon\Carbon;
+
 
 class FashionController extends Controller
 {
@@ -95,6 +102,12 @@ class FashionController extends Controller
 
         // 該当するデータを上書きして保存する
         $fashion->fill($fashion_form)->save();
+
+        // Fashion Modelを保存するタイミングで、同時にHistory Modelにも編集履歴を追加する
+        $history = new History();
+        $history->fashion_id = $fashion->id;
+        $history->edited_at = Carbon::now();
+        $history->save();
 
         return redirect('admin/fashion');
     }

--- a/app/Models/Fashion.php
+++ b/app/Models/Fashion.php
@@ -15,4 +15,10 @@ class Fashion extends Model
         'title' => 'required',
         'body' => 'required',
     );
+
+    // Fashion Modelに関連付けを行う
+    public function histories()
+    {
+        return $this->hasMany('App\Models\History');
+    }
 }

--- a/app/Models/History.php
+++ b/app/Models/History.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class History extends Model
+{
+    use HasFactory;
+
+    protected $guarded = array('id');
+
+    public static $rules = array(
+        'fashion_id' => 'required',
+        'edited_at' => 'required',
+    );
+}

--- a/database/migrations/2024_10_05_135712_create_histories_table.php
+++ b/database/migrations/2024_10_05_135712_create_histories_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('histories', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('fashion_id');
+            $table->string('edited_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('histories');
+    }
+};

--- a/resources/views/admin/fashion/edit.blade.php
+++ b/resources/views/admin/fashion/edit.blade.php
@@ -48,6 +48,20 @@
                         </div>
                     </div>
                 </form>
+                {{-- 編集履歴の画面を追記 --}}
+                <div class="row mt-5">
+                    <div class="col-md-4 mx-auto">
+                        <h2>編集履歴</h2>
+                        <ul class="list-group">
+                            @if ($fashion_form->histories != NULL)
+                                @foreach ($fashion_form->histories as $history)
+                                    <li class="list-group-item">{{ $history->edited_at }}</li>
+                                @endforeach
+                            @endif
+                        </ul>
+                    </div>
+                </div>
+                {{-- 編集履歴の画面ここまで --}}
             </div>
         </div>
     </div>


### PR DESCRIPTION
・histories_table.phpというmigrationファイルを作成し、編集する
・History Modelのひな形を作成し、app/Models/History.php を編集してHistory Modelを実装する
・Fashion Modelとの関連を定義するために、app/Models/Fashion.phpを編集する
・FashionController の update Actionで、Fashion Modelを保存するタイミングで、同時に History Modelにも編集履歴を追加するよう実装する
・FashionController.phpに、時刻を扱えるようにするための追記をする
・edit.blade.phpを編集して、記録した変更履歴を編集画面で参照できるようにする