### PR TITLE
ホーム画面と検索結果表示画面で、トップの新規投稿の表示を変更する指示を追加 #39

### DIFF
--- a/app/Http/Controllers/FashionController.php
+++ b/app/Http/Controllers/FashionController.php
@@ -12,13 +12,13 @@ class FashionController extends Controller
 {
     public function index(Request $request)
     {
-        $posts = Fashion::orderBy('updated_at', 'desc')->paginate(10);
-
-        if (count($posts) > 0) {
-            $headline = $posts->shift();
-        } else {
+        $headline = Fashion::orderBy('updated_at', 'desc')->first();
+        if (!$headline) {
             $headline = null;
         }
+    
+        $posts = Fashion::orderBy('updated_at', 'desc')->paginate(10);
+        
 
         // fashion/index.blade.php ファイルを渡している
         // また View テンプレートに headline、 posts、という変数を渡している
@@ -39,12 +39,8 @@ class FashionController extends Controller
                             ->orderBy('updated_at', 'desc')->paginate(10);
         }
         
-        if (count($posts) > 0) {
-            $headline = $posts->shift();
-        } else {
-            $headline = null;
-        }
-        
+        $headline = null;
+        //dd($posts);
         return view('fashion.index', ['headline' => $headline, 'posts' => $posts]);
     }
 }

--- a/resources/sass/front.scss
+++ b/resources/sass/front.scss
@@ -29,7 +29,7 @@ body {
   .headline {
     .caption {
       position: relative;
-      width: 350px;
+      width: 120px;
       .image {
         img {
       width: 100%;

--- a/resources/views/fashion/index.blade.php
+++ b/resources/views/fashion/index.blade.php
@@ -3,9 +3,9 @@
     <div class="container">
         <hr color="#C0C0C0">
         @if (!is_null($headline))
-            <h1>New! -新着スタイリングスナップ-</h1>
             <div class="row">
                 <div class="headline col-md-10 mx-auto">
+                    <h3>New! -新着スタイリングスナップ-</h3>
                     <div class="row">
                         <div class="col-md-6">
                             <div class="caption mx-auto">
@@ -25,31 +25,34 @@
                     </div>
                 </div>
             </div>
-        @else
-            検索結果はありませんでした。
+            <hr color="#C0C0C0">
         @endif
-        <hr color="#C0C0C0">
         <div class="row">
-            {{-- 投稿を3つ横並びに表示する設定 --}}
-            @foreach ($posts as $post)
-                <div class="col-md-4">
-                    <div class="date">
-                        {{ $post->updated_at->format('Y年m月d日') }}
-                    </div>
-                    <div class="title">
-                        {{ Str::limit($post->title, 150) }}
-                    </div>
-                    <div class="body mt-3">
-                        {{ Str::limit($post->body, 1500) }}
-                    </div>
+            @if ($posts->isNotEmpty())
+                {{-- 投稿を3つ横並びに表示する設定 --}}
+                @foreach ($posts as $post)
+                    <div class="col-md-4">
+                        <div class="date">
+                            {{ $post->updated_at->format('Y年m月d日') }}
+                        </div>
+                        <div class="title">
+                            {{ Str::limit($post->title, 150) }}
+                        </div>
+                        <div class="body mt-3">
+                            {{ Str::limit($post->body, 1500) }}
+                        </div>
 
-                    <div class="image text-right mt-4">
-                        @if ($post->image_path)
-                            <img src="{{ asset('storage/image/' . $post->image_path) }}">
-                        @endif
+                        <div class="image text-right mt-4">
+                            @if ($post->image_path)
+                                <img src="{{ asset('storage/image/' . $post->image_path) }}">
+                            @endif
+                        </div>
                     </div>
-                </div>
-            @endforeach
+                @endforeach
+            @else
+                検索結果はありませんでした。
+            @endif
+
         </div>
         <div class="row">
         {{ $posts->appends(request()->query())->links() }}


### PR DESCRIPTION
ホーム画面には最新の投稿がheadlineに出るようにして（トップ位置に独立表示）、検索結果を表示する画面ではheadlineの表示をしないように指示する。